### PR TITLE
Fix warning on array_merge if $model->data[$habtmAlias][$habtmAlias] is empty

### DIFF
--- a/Model/Behavior/HabtmCounterCacheBehavior.php
+++ b/Model/Behavior/HabtmCounterCacheBehavior.php
@@ -288,10 +288,12 @@ class HabtmCounterCacheBehavior extends ModelBehavior {
       }
 
       // If there are old habtm ids merge them with the new ones
-      $this->_habtmIds[$model->alias][$model->id][$habtmAlias] = array_unique(array_merge(
-        $this->_habtmIds[$model->alias][$model->id][$habtmAlias],
-        $model->data[$habtmAlias][$habtmAlias]
-      ));
+      if (!empty($model->data[$habtmAlias][$habtmAlias])) {
+        $this->_habtmIds[$model->alias][$model->id][$habtmAlias] = array_unique(array_merge(
+          $this->_habtmIds[$model->alias][$model->id][$habtmAlias],
+          $model->data[$habtmAlias][$habtmAlias]
+        ));
+      }
 
     }
   }


### PR DESCRIPTION
i add an if to fix warning on array_merge if $model->data[$habtmAlias][$habtmAlias] is empty
